### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jlesage/baseimage-gui:ubuntu-16.04-v3
+FROM jlesage/baseimage-gui:ubuntu-18.04-v3
 
 RUN apt-get update -y
 RUN apt-get upgrade -y


### PR DESCRIPTION
Move base image from Ubuntu 16.04v3 to 18.04v3 - as officially supported https://mediaelch.github.io/mediaelch-doc/download.html